### PR TITLE
changing semver to be in line with actual react-scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everlong/league-react-scripts",
-  "version": "0.1.1",
+  "version": "3.0.1",
   "description": "Everlong configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Storybook does a check to see if the version of react-scripts is greater than 2+.

We should make our version just match react-scripts so storybook does not break