### PR TITLE
[FRONTEND-99] [Web] fix IE issue in v3.3.1 via hack to include `Object.entries` pollyfill from core-js

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -158,6 +158,13 @@ module.exports = function(webpackEnv) {
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
     entry: [
+      // START: EVERLONG CHANGES - FRONTEND-99
+      // this is hopefully a temporary fix for
+      // https://github.com/facebook/create-react-app/issues/8405
+      // from this comment:https://github.com/facebook/create-react-app/issues/8405#issuecomment-582388530
+      './node_modules/core-js/es/object/entries.js',
+      // END: EVERLONG CHANGES - FRONTEND-99
+
       // Include an alternative client for WebpackDevServer. A client's job is to
       // connect to WebpackDevServer by a socket and get notified about changes.
       // When you save a file, the client will either apply hot updates (in case

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everlong/league-react-scripts",
-  "version": "3.3.1",
+  "version": "3.3.1-pr9",
   "description": "Everlong configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I had to do a temporary hack to the CRA Webpack config to fix a babel issue in react-error-overlay 
https://github.com/facebook/create-react-app/issues/8405#issuecomment-582388530
 
I am following this issue and will update our fork to revert the hack when the issue is properly resolved. 

I’ve created a separate issue to track that: https://everlong.atlassian.net/browse/FRONTEND-100

### Note
This hack bring the Object.entries pollyfill in for all environments / browsers. I don't think that's a huge problem but something to monitor and roll back from asap.
 