### PR TITLE
Yaml fix for publishing to private registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ aliases:
     run: yarn install --frozen-lockfile
 
 version: 2.1
+jobs:
   publish-package:
     <<: *defaults
     steps:


### PR DESCRIPTION
This was failing because:
a) I made a yaml error, James helped me fix this
b) I had to update react scripts due to a Babel error:

https://stackoverflow.com/a/60804157

So now we're at 3.4.1 in master, and then these worked!

Note: master is currently broken with a red "X" because this yaml fix is not in there.

## Checked in IE 11
Checked in IE 11, login works.