### PR TITLE
adding yarn publish command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "cd packages/react-scripts && node bin/react-scripts.js test",
     "format": "prettier --trailing-comma es5 --single-quote --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
     "compile:lockfile": "node tasks/compile-lockfile.js",
-    "publish-package": "echo $GOOGLE_AUTH_B64 | base64 --decode > .google_creds && GOOGLE_APPLICATION_CREDENTIALS=.google_creds npx google-artifactregistry-auth .npmrc && rm -f .google_creds && yarn publish"
+    "publish-package": "echo $GOOGLE_AUTH_B64 | base64 --decode > .google_creds && GOOGLE_APPLICATION_CREDENTIALS=$(cat .google_creds) npx google-artifactregistry-auth .npmrc && rm -f .google_creds && yarn publish"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "alex": "alex .",
     "test": "cd packages/react-scripts && node bin/react-scripts.js test",
     "format": "prettier --trailing-comma es5 --single-quote --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
-    "compile:lockfile": "node tasks/compile-lockfile.js"
+    "compile:lockfile": "node tasks/compile-lockfile.js",
+    "publish-package": "echo $GOOGLE_AUTH_B64 | base64 --decode > .google_creds && GOOGLE_APPLICATION_CREDENTIALS=.google_creds npx google-artifactregistry-auth .npmrc && rm -f .google_creds && yarn publish"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "cd packages/react-scripts && node bin/react-scripts.js test",
     "format": "prettier --trailing-comma es5 --single-quote --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
     "compile:lockfile": "node tasks/compile-lockfile.js",
-    "publish-package": "echo $GOOGLE_AUTH_B64 | base64 --decode > .google_creds && GOOGLE_APPLICATION_CREDENTIALS=$(cat .google_creds) npx google-artifactregistry-auth .npmrc && rm -f .google_creds && yarn publish"
+    "publish-package": "echo $GOOGLE_AUTH_B64 | base64 --decode > .google_creds && GOOGLE_APPLICATION_CREDENTIALS=.google_creds npx google-artifactregistry-auth .npmrc && rm -f .google_creds && yarn publish"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.0",


### PR DESCRIPTION
Related to these errors:

https://circleci.com/gh/EverlongProject/create-react-app/6

# Cache
```
Error computing cache key: template: cacheKey:1:15: executing "cacheKey" at <checksum "yarn.lock">: error calling checksum: open /home/circleci/project/yarn.lock: no such file or directory
```

^^ not sure how to fix this one @jamesrwu any ideas? It could be that the `yarn.lock` file does not exist yet?!

## Adding publish-package command:
```
#!/bin/bash -eo pipefail
yarn publish-package
yarn run v1.17.3
error Command "publish-package" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Exited with code exit status 1
```

Reference:
https://github.com/EverlongProject/genesis/blob/master/react/package.json#L30