### PR TITLE
publishing workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "cd packages/react-scripts && node bin/react-scripts.js test",
     "format": "prettier --trailing-comma es5 --single-quote --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
     "compile:lockfile": "node tasks/compile-lockfile.js",
-    "publish-package": "echo $GOOGLE_AUTH_B64 | base64 --decode > .google_creds && GOOGLE_APPLICATION_CREDENTIALS=.google_creds npx google-artifactregistry-auth .npmrc && rm -f .google_creds && yarn publish"
+    "publish-package": "yarn workspace @everlong/league-react-scripts publish-package"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -24,6 +24,9 @@
     "template-typescript",
     "utils"
   ],
+  "scripts": {
+    "publish-package": "echo $GOOGLE_AUTH_B64 | base64 --decode > .google_creds && GOOGLE_APPLICATION_CREDENTIALS=.google_creds npx google-artifactregistry-auth .npmrc && rm -f .google_creds && yarn publish"
+  },
   "bin": {
     "react-scripts": "./bin/react-scripts.js"
   },


### PR DESCRIPTION
We want to publish packages/react-scripts (aka `@everlong/league-react-scripts`) NOT the root package, which is private.